### PR TITLE
Add EAN-8 to the list of supported bar codes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -20,7 +20,7 @@ require './xbi'
 
 use Rack::Session::Cookie, secret: ENV['COOKIE_SECRET']
 
-$banned_resize = ["upca", "qrcode", "pdf417", "code39", "code128", "ean13", "rationalizedCodabar", "interleaved2of5"]
+$banned_resize = ["upca", "qrcode", "pdf417", "code39", "code128", "ean13", "ean8", "rationalizedCodabar", "interleaved2of5"]
 $linear_formats = ["code39", "code128", "ean8", "ean13", "upca", "rationalizedCodabar", "interleaved2of5"]
 
 def pebble_barcode(type, card)

--- a/app.rb
+++ b/app.rb
@@ -6,6 +6,7 @@ require 'uri'
 
 require 'barby'
 require 'barby/barcode/qr_code'
+require 'barby/barcode/ean_8'
 require 'barby/barcode/ean_13'
 require 'barby/outputter/png_outputter'
 
@@ -20,7 +21,7 @@ require './xbi'
 use Rack::Session::Cookie, secret: ENV['COOKIE_SECRET']
 
 $banned_resize = ["upca", "qrcode", "pdf417", "code39", "code128", "ean13", "rationalizedCodabar", "interleaved2of5"]
-$linear_formats = ["code39", "code128", "ean13", "upca", "rationalizedCodabar", "interleaved2of5"]
+$linear_formats = ["code39", "code128", "ean8", "ean13", "upca", "rationalizedCodabar", "interleaved2of5"]
 
 def pebble_barcode(type, card)
   maxpixelcount = (256-3)*8

--- a/public/script.js
+++ b/public/script.js
@@ -23,6 +23,11 @@ function collectData(strictValidation) {
       return false;
     }
 
+    if (strictValidation && $("[name='barcode_" + i + "_type']").val() == "ean8" && $("[name='barcode_" + i + "_data']").val().length !== 8) {
+      alert("EAN-8 barcodes must have 8 numbers!");
+      return false;
+    }
+
     if (strictValidation && $("[name='barcode_" + i + "_type']").val() == "upca" && $("[name='barcode_" + i + "_data']").val().length !== 12) {
       alert("UPC-A barcodes must have 12 numbers!");
       return false;
@@ -141,6 +146,11 @@ function restrictInput(value, i) {
 
     case 'ean13':
       $("[name='barcode_" + i + "_data']").attr("maxlength", 13);
+      $("[name='barcode_" + i + "_data']").attr("pattern", "\\d*");
+      break;
+
+    case 'ean8':
+      $("[name='barcode_" + i + "_data']").attr("maxlength", 8);
       $("[name='barcode_" + i + "_data']").attr("pattern", "\\d*");
       break;
 

--- a/views/settings.erb
+++ b/views/settings.erb
@@ -35,6 +35,7 @@
                 <option value="rationalizedCodabar">Codabar</option>
                 <option value="code39">Code 39</option>
                 <option value="code128">Code 128</option>
+                <option value="ean8">EAN-8</option>
                 <option value="ean13">EAN-13</option>
                 <option value="interleaved2of5">Interleaved 2 of 5 (ITF)</option>
                 <option value="upca">UPC-A</option>

--- a/xbi.rb
+++ b/xbi.rb
@@ -34,10 +34,8 @@ module ChunkyPNG
       end
 
       # pad bit_data to ensure it will nicely fit when converted to binary proper
-      if bit_data.length % 8 != 0
-        for i in 1...bit_data.length % 8 do
-          bit_data << '0'
-        end
+      while bit_data.length % 8 != 0 do
+        bit_data << '0'
       end
 
       bit = bit_data.scan(/.{8}/)


### PR DESCRIPTION
These are the trivial changes to add EAN-8 (my video rental store uses that) to the list of supported bar codes.
