### PR TITLE
Prepare for Heroku deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.7
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY public ./public/
+COPY views ./views/
+COPY app.rb config.ru env.rb xbi.rb ./
+
+ENTRYPOINT exec bundle exec thin -R config.ru start -p $PORT -e $RACK_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN bundle install
 
 COPY public ./public/
 COPY views ./views/
-COPY app.rb config.ru env.rb xbi.rb ./
+COPY app.rb config.ru xbi.rb ./
 
 ENTRYPOINT exec bundle exec thin -R config.ru start -p $PORT -e $RACK_ENV

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec thin -R config.ru start -p $PORT -e $RACK_ENV

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ to start the web server.
 If you want to point your Pebble at your web server, change Skunk's `src/js/pebble-app-js.js`'s
 third line to your computer's IP address. You can then push the modified Skunk build
 to your phone using the usual `pebble build && pebble install` or CloudPebble.
+
+Privacy
+-------
+skunk-config is hosted on servers located in the United Kingdom 🇬🇧 through the [canidae.systems](https://canidae.systems/)
+cluster for public use at `skunk-config.canidae.systems`.
+
+Analytics are not collected. User data is temporarily stored in-memory for the
+purpose of providing server-side barcode generation and is deleted after processing.
+
+You can also run your own instance of skunk-config, modifying [pebble-js-app.js](https://github.com/unlobito/skunk/blob/main/src/js/pebble-js-app.js#L3)
+to point at your own infrastructure.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  skunk-config:
+    build: .
+    environment:
+      PORT: "5555"
+      RACK_ENV: "production"
+    ports:
+      - 5555:5555

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     environment:
       PORT: "5555"
       RACK_ENV: "production"
+      COOKIE_SECRET: ""
     ports:
       - 5555:5555


### PR DESCRIPTION
> skunk's latest release (v1.6.0, from 2016-08-23!) relies on Heroku to host [unlobito/skunk-config](https://github.com/unlobito/skunk-config) for the config panel and barcode bitmap rendering. This won't be sustainable beyond 2022-11-28 due to changes in Heroku's free dyno offering ([#34](https://github.com/unlobito/skunk/issues/34) / [Heroku's Next Chapter](https://blog.heroku.com/next-chapter)).
> 
> ⚠️ `skunk-config.canidae.systems` isn't ready for public use. This PR and https://github.com/unlobito/skunk/pull/35 will be merged once the dust settles.

- [x] **Dockerfile**: migrate runtime from `Procfile`
- [x] **docker-compose.yml**: local runtime
- [x] **skunk-config.canidae.systems**: created DNS records
- [x] **README.md**: write privacy policy
- [x] **skunk-config.canidae.systems**: accept public traffic