### PR TITLE
Support the Pebble emulator's use of the ?return_to parameter.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -227,7 +227,8 @@ function generatePebbleURL() {
 
   data_str = base64_encode(JSON.stringify(data));
 
-  location.href = 'pebblejs://close#' + data_str;
+  var return_to = new URLSearchParams(location.search).get('return_to') || 'pebblejs://close#';
+  location.href = return_to + data_str;
 }
 
 function restrictInput(value, i) {


### PR DESCRIPTION
This allows testing skunk easily in the emulator by running `pebble emu-app-config`.